### PR TITLE
Fix resource definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /behat.yml
 /phpspec.yml
 /phpunit.xml
+
+/.idea/

--- a/src/Repository/AbstractLogEntryRepository.php
+++ b/src/Repository/AbstractLogEntryRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brille24\SyliusOrderLogPlugin\Repository;
+
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+
+abstract class AbstractLogEntryRepository extends EntityRepository implements LogEntryRepositoryInterface
+{
+    public function createByObjectIdQueryBuilder(string $objectId): QueryBuilder
+    {
+        return $this->createQueryBuilder('log')
+            ->where('log.objectId = :objectId')
+            ->setParameter('objectId', $objectId)
+            ;
+    }
+
+    public function createByOrderIdQueryBuilder(string $orderId): QueryBuilder
+    {
+        return $this->createQueryBuilder('log')
+            ->where('log.orderId = :orderId')
+            ->setParameter('orderId', $orderId)
+            ;
+    }
+}

--- a/src/Repository/LogEntryRepositoryInterface.php
+++ b/src/Repository/LogEntryRepositoryInterface.php
@@ -7,7 +7,7 @@ namespace Brille24\SyliusOrderLogPlugin\Repository;
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\ResourceLogEntryRepositoryInterface;
 
-interface OrderLogEntryRepositoryInterface extends ResourceLogEntryRepositoryInterface
+interface LogEntryRepositoryInterface extends ResourceLogEntryRepositoryInterface
 {
     public function createByOrderIdQueryBuilder(string $objectId): QueryBuilder;
 }

--- a/src/Repository/PaymentLogEntryRepository.php
+++ b/src/Repository/PaymentLogEntryRepository.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Brille24\SyliusOrderLogPlugin\Repository;
 
-class OrderLogEntryRepository extends AbstractLogEntryRepository
+class PaymentLogEntryRepository extends AbstractLogEntryRepository
 {
 }

--- a/src/Repository/ShipmentLogEntryRepository.php
+++ b/src/Repository/ShipmentLogEntryRepository.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Brille24\SyliusOrderLogPlugin\Repository;
 
-class OrderLogEntryRepository extends AbstractLogEntryRepository
+class ShipmentLogEntryRepository extends AbstractLogEntryRepository
 {
 }

--- a/src/Resources/config/app/resource.yml
+++ b/src/Resources/config/app/resource.yml
@@ -10,10 +10,10 @@ sylius_resource:
       classes:
         model: 'Brille24\SyliusOrderLogPlugin\Entity\PaymentLogEntry'
         interface: 'Brille24\SyliusOrderLogPlugin\Entity\PaymentLogEntryInterface'
-        repository: 'Brille24\SyliusOrderLogPlugin\Repository\OrderLogEntryRepository'
+        repository: 'Brille24\SyliusOrderLogPlugin\Repository\PaymentLogEntryRepository'
 
     brille24.shipment_log_entry:
       classes:
         model: 'Brille24\SyliusOrderLogPlugin\Entity\ShipmentLogEntry'
         interface: 'Brille24\SyliusOrderLogPlugin\Entity\ShipmentLogEntryInterface'
-        repository: 'Brille24\SyliusOrderLogPlugin\Repository\OrderLogEntryRepository'
+        repository: 'Brille24\SyliusOrderLogPlugin\Repository\ShipmentLogEntryRepository'


### PR DESCRIPTION
The new ResourceBundle version no longer allows to use the same Repository class for different resources. (Except for the EntityRepository)